### PR TITLE
Wi-Fi Association Bug Fix for BCM

### DIFF
--- a/src/lib/bcmwl/src/bcmwl_vap.c
+++ b/src/lib/bcmwl/src/bcmwl_vap.c
@@ -537,7 +537,12 @@ void bcmwl_vap_prealloc_all(void)
             bssmax = bcmwl_radio_max_vifs(p->d_name);
             if (bssmax > BCMWL_VAP_PREALLOC_MAX)
                 bssmax = BCMWL_VAP_PREALLOC_MAX;
-            bcmwl_vap_prealloc(p->d_name, bssmax - 1, bcmwl_vap_mac_xfrm);
+            if(bssmax > 8){
+                    bcmwl_vap_prealloc(p->d_name, bssmax - 1, bcmwl_vap_mac_xfrm);
+            }else{
+		    //Adding a log here would be helpful to inform the developer/integrator
+                    bcmwl_vap_prealloc(p->d_name, bssmax - 2, bcmwl_vap_mac_xfrm);
+            }
         }
     }
 


### PR DESCRIPTION
while integrating opensync 6.2 with BCM 5.04.04p3 it was observed that the extender devices could not associate with the onboard AP.

Further analysis revealed that the SDK was set to the default value for BSS (bssmax = 8). Since opensync was trying to bring up interfaces ranging from wlx.1 to wlx.7 by default, there was some conflict that caused the failure in the leaf association.

The following fix addresses the issue if the SDK comes with default values, the leaf will still be able to associate with the GW and bring up the APs. The VIFs wlx.1 to wlx.6 will be brought up in this case.

This can help with the normal operation of the leaf device. However, it will be better to request the ODM for this requirement (bssmax at least 10) in intake form / TRD when they approach for Integration/Certification with the plume team.